### PR TITLE
ci: add workflow for publishing the Docker image to the GHCR

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,59 @@
+# This workflow publishes a Docker image to GitHub Packages.
+# Copied and adjusted from https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+name: Build and publish Docker image
+
+# Run every time a change is pushed to the branch called `release`.
+on:
+  workflow_dispatch:
+
+# Define the Container registry domain, and the name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      # TODO: check if this is needed
+      # - name: Checkout repository
+      #   uses: actions/checkout@v4
+      # Use the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Use the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.15.0
+        with:
+          # TODO: check if this is needed
+          # context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pandoc Resume Docker
+# Pandoc Resume
 
 This repository provides a Docker-based solution for generating beautiful resumes using the [pandoc_resume](https://github.com/mszep/pandoc_resume) project.
 
@@ -19,10 +19,10 @@ vim resume.md
 
 ```bash
 # Basic usage (generates resume.pdf and resume.html in the same directory)
-docker run -v $(pwd):/resume ghcr.io/ruancomelli/pandoc-resume-docker resume.md
+docker run -v $(pwd):/resume ghcr.io/ruancomelli/pandoc-resume resume.md
 
 # Specify input and output files
-docker run -v $(pwd):/resume ghcr.io/ruancomelli/pandoc-resume-docker path/to/my/cv.md -o path/to/output/cv.pdf
+docker run -v $(pwd):/resume ghcr.io/ruancomelli/pandoc-resume path/to/my/cv.md -o path/to/output/cv.pdf
 ```
 
 The command will generate:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,15 @@ cd /app/pandoc_resume
 # Run make to generate the resume
 make
 
+# TODO: Use this to generate the resume
+# docker run --rm \
+# 	--volume "`pwd`:/data" \
+# 	pandoc/latex \
+# 	--pdf-engine=xelatex \
+# 	-f markdown+smart+multiline_tables \
+# 	"/data/$input_file" \
+# 	-o "/data/$output_file"
+
 # Check if PDF was generated
 if [ ! -f "output/resume.pdf" ]; then
     echo "Error: PDF generation failed"


### PR DESCRIPTION
## Summary by Sourcery

Adds a GitHub Actions workflow to build and publish the Docker image to GitHub Container Registry (GHCR). Updates the README with the correct Docker image name.

CI:
- Adds a workflow to build and publish the Docker image to GHCR.
- Generates an artifact attestation for the image to increase supply chain security.

Documentation:
- Updates the README with the correct Docker image name.